### PR TITLE
add an editor and types

### DIFF
--- a/src/SimpleEditor.tsx
+++ b/src/SimpleEditor.tsx
@@ -1,0 +1,21 @@
+import React, { PureComponent } from 'react';
+import { PanelEditorProps, FormField } from '@grafana/ui';
+
+import { SimpleOptions } from './types';
+
+export class SimpleEditor extends PureComponent<PanelEditorProps<SimpleOptions>> {
+  onTextChanged = ({ target }: any) => {
+    this.props.onOptionsChange({ ...this.props.options, text: target.value });
+  };
+
+  render() {
+    const { options } = this.props;
+
+    return (
+      <div className="section gf-form-group">
+        <h5 className="section-heading">Display</h5>
+        <FormField label="Text" labelWidth={5} inputWidth={20} type="text" onChange={this.onTextChanged} value={options.text || ''} />
+      </div>
+    );
+  }
+}

--- a/src/SimplePanel.tsx
+++ b/src/SimplePanel.tsx
@@ -1,0 +1,12 @@
+import React, { PureComponent } from 'react';
+import { PanelProps } from '@grafana/ui';
+import { SimpleOptions } from 'types';
+
+interface Props extends PanelProps<SimpleOptions> {}
+
+export class SimplePanel extends PureComponent<Props> {
+  render() {
+    const { options } = this.props;
+    return <div>Hello: {options.text}</div>;
+  }
+}

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -1,10 +1,6 @@
-import React, { PureComponent } from 'react';
-import { PanelProps, PanelPlugin } from '@grafana/ui';
+import { PanelPlugin } from '@grafana/ui';
+import { SimpleOptions, defaults } from './types';
+import { SimplePanel } from './SimplePanel';
+import { SimpleEditor } from './SimpleEditor';
 
-export class MyPanel extends PureComponent<PanelProps> {
-  render() {
-    return <div>Hello from my panel</div>;
-  }
-}
-
-export const plugin = new PanelPlugin(MyPanel);
+export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setDefaults(defaults).setEditor(SimpleEditor);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,7 @@
+export interface SimpleOptions {
+  text: string;
+}
+
+export const defaults: SimpleOptions = {
+  text: 'The default text!',
+};


### PR DESCRIPTION
The example needs a basic editor and types pattern.  Now it has the so so interesting UI:

![image](https://user-images.githubusercontent.com/705951/67175911-2d44c080-f3c8-11e9-99a1-5607119e4a08.png)
