### PR TITLE
Set is-promise version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@grafana/ui": "canary"
   },
   "resolutions": {
-    "@babel/preset-env": "7.9.0"
+    "@babel/preset-env": "7.9.0",
+    "is-promise": "2.2.2"
   },
   "engines": {
     "node": ">=12 <13"


### PR DESCRIPTION
`is-promise@2.2.0` is broken, this resolves to `2.2.2` containing the fix.

https://medium.com/javascript-in-plain-english/is-promise-post-mortem-cab807f18dcc